### PR TITLE
fix(bcrypt): potential panic in badly formed hash

### DIFF
--- a/bcrypt/bcrypt.go
+++ b/bcrypt/bcrypt.go
@@ -158,14 +158,18 @@ func newFromHash(hashedSecret []byte) (*hashed, error) {
 }
 
 func DecodeSecret(secret []byte) (salt, key []byte) {
+	switch s := len(secret); {
+	case s == 0:
+		return nil, nil
+	case s < EncodedSaltSize:
+		return secret, nil
+	default:
+		salt, key = make([]byte, EncodedSaltSize, EncodedSaltSize+2), make([]byte, len(secret)-EncodedSaltSize)
 
-	salt = make([]byte, encodedSaltSize, encodedSaltSize+2)
+		copy(salt, secret[:EncodedSaltSize])
 
-	copy(salt, secret[:encodedSaltSize])
-
-	key = make([]byte, len(secret)-encodedSaltSize)
-
-	copy(key, secret[encodedSaltSize:])
+		copy(key, secret[EncodedSaltSize:])
+	}
 
 	return
 }
@@ -237,9 +241,9 @@ func (p *hashed) Hash() []byte {
 	arr[n] = '$'
 	n++
 	copy(arr[n:], p.salt)
-	n += encodedSaltSize
+	n += EncodedSaltSize
 	copy(arr[n:], p.hash)
-	n += encodedHashSize
+	n += EncodedHashSize
 	return arr[:n]
 }
 

--- a/bcrypt/bcrypt_test.go
+++ b/bcrypt/bcrypt_test.go
@@ -7,8 +7,46 @@ package bcrypt
 import (
 	"bytes"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
+
+func TestDecodeSecret(t *testing.T) {
+	testCases := []struct {
+		name         string
+		have         []byte
+		expected     []byte
+		expectedSalt []byte
+	}{
+		{
+			"ShouldDecode",
+			[]byte("gKt7Q/V29tf48wMkEoYlNOk.XttO4IJdWKVDQPHLxkZMs9VEFwfv2"),
+			[]byte("k.XttO4IJdWKVDQPHLxkZMs9VEFwfv2"),
+			[]byte("gKt7Q/V29tf48wMkEoYlNO"),
+		},
+		{
+			"ShouldNotPanicWithShortSalt",
+			[]byte("gKt7Q/V29tf48wMkEoYlN"),
+			[]byte(nil),
+			[]byte("gKt7Q/V29tf48wMkEoYlN"),
+		},
+		{
+			"ShouldNotPanicWithEmptySecret",
+			[]byte(""),
+			nil,
+			nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			salt, key := DecodeSecret(tc.have)
+
+			assert.Equal(t, tc.expected, key)
+			assert.Equal(t, tc.expectedSalt, salt)
+		})
+	}
+}
 
 func TestBcryptingIsEasy(t *testing.T) {
 	pass := []byte("mypassword")

--- a/bcrypt/const.go
+++ b/bcrypt/const.go
@@ -1,9 +1,11 @@
 package bcrypt
 
 const (
-	MinCost     int = 4  // the minimum allowable cost as passed in to GenerateFromPassword
-	MaxCost     int = 31 // the maximum allowable cost as passed in to GenerateFromPassword
-	DefaultCost int = 10 // the cost that will actually be set if a cost below MinCost is passed into GenerateFromPassword
+	MinCost         int = 4  // the minimum allowable cost as passed in to GenerateFromPassword
+	MaxCost         int = 31 // the maximum allowable cost as passed in to GenerateFromPassword
+	DefaultCost     int = 10 // the cost that will actually be set if a cost below MinCost is passed into GenerateFromPassword
+	EncodedSaltSize     = 22
+	EncodedHashSize     = 31
 )
 
 const (
@@ -11,8 +13,6 @@ const (
 	minorVersion       = 'a'
 	maxSaltSize        = 16
 	maxCryptedHashSize = 23
-	encodedSaltSize    = 22
-	encodedHashSize    = 31
 	minHashSize        = 59
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,13 @@ module github.com/go-crypt/x
 
 go 1.20
 
-require golang.org/x/sys v0.9.0
+require (
+	github.com/stretchr/testify v1.8.4
+	golang.org/x/sys v0.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
 golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This fixes a potential panic in badly formed bcrypt hashes. It's important to note that this is not intended as a catch all and that input validation is the implementers job. As such we've exposed the constants required to do this.