### PR TITLE
fix(bcrypt): no error on invalid hashes

### DIFF
--- a/bcrypt/bcrypt_test.go
+++ b/bcrypt/bcrypt_test.go
@@ -17,33 +17,45 @@ func TestDecodeSecret(t *testing.T) {
 		have         []byte
 		expected     []byte
 		expectedSalt []byte
+		shouldPanic  bool
 	}{
 		{
 			"ShouldDecode",
 			[]byte("gKt7Q/V29tf48wMkEoYlNOk.XttO4IJdWKVDQPHLxkZMs9VEFwfv2"),
 			[]byte("k.XttO4IJdWKVDQPHLxkZMs9VEFwfv2"),
 			[]byte("gKt7Q/V29tf48wMkEoYlNO"),
+			false,
 		},
 		{
-			"ShouldNotPanicWithShortSalt",
+			"ShouldPanicOnInvalidSize",
 			[]byte("gKt7Q/V29tf48wMkEoYlN"),
-			[]byte(nil),
-			[]byte("gKt7Q/V29tf48wMkEoYlN"),
+			nil,
+			nil,
+			true,
 		},
 		{
-			"ShouldNotPanicWithEmptySecret",
+			"ShouldPanicWithEmptySecret",
 			[]byte(""),
 			nil,
 			nil,
+			true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			salt, key := DecodeSecret(tc.have)
+			if tc.shouldPanic {
+				assert.Panics(t, func() {
+					_, _ = DecodeSecret(tc.have)
+				})
+			} else {
+				assert.NotPanics(t, func() {
+					salt, key := DecodeSecret(tc.have)
 
-			assert.Equal(t, tc.expected, key)
-			assert.Equal(t, tc.expectedSalt, salt)
+					assert.Equal(t, tc.expected, key)
+					assert.Equal(t, tc.expectedSalt, salt)
+				})
+			}
 		})
 	}
 }

--- a/bcrypt/errors.go
+++ b/bcrypt/errors.go
@@ -5,13 +5,18 @@ import (
 	"fmt"
 )
 
-// ErrMismatchedHashAndPassword is the error returned from CompareHashAndPassword when a password and hash do
-// not match.
-var ErrMismatchedHashAndPassword = errors.New("github.com/go-crypt/x/bcrypt: hashedPassword is not the hash of the given password")
+var (
+	// ErrMismatchedHashAndPassword is the error returned from CompareHashAndPassword when a password and hash do
+	// not match.
+	ErrMismatchedHashAndPassword = errors.New("github.com/go-crypt/x/bcrypt: the provided password is not a match for the provided hashed password")
 
-// ErrHashTooShort is the error returned from CompareHashAndPassword when a hash is too short to
-// be a bcrypt hash.
-var ErrHashTooShort = errors.New("github.com/go-crypt/x/bcrypt: hashedSecret too short to be a bcrypted password")
+	// ErrHashTooShort is the error returned from CompareHashAndPassword when a hash is too short to
+	// be a bcrypt hash.
+	ErrHashTooShort = errors.New("github.com/go-crypt/x/bcrypt: hashed secret key is too short to be a bcrypt hashed secret key")
+
+	// ErrSecretInvalidLength is the error returned when a hash secret is too short to be a bcrypt secret.
+	ErrSecretInvalidLength = errors.New("github.com/go-crypt/x/bcrypt: secret has an invalid length for a bcrypt secret")
+)
 
 // The error returned from CompareHashAndPassword when a hash was created with
 // a bcrypt algorithm newer than this implementation.


### PR DESCRIPTION
Fixes an issue introduced by fixing the unexpected panic when using decode secret. As the length of a secret is fixed this should not be allowed.