### PR TITLE
feat(blake2b): add go 1.25 xof

### DIFF
--- a/blake2b/blake2x.go
+++ b/blake2b/blake2x.go
@@ -12,6 +12,8 @@ import (
 
 // XOF defines the interface to hash functions that
 // support arbitrary-length output.
+//
+// New callers should prefer the standard library [hash.XOF].
 type XOF interface {
 	// Write absorbs more data into the hash's state. It panics if called
 	// after Read.
@@ -35,6 +37,8 @@ type XOF interface {
 //
 // A non-nil key turns the hash into a MAC. The key must between
 // zero and 32 bytes long.
+//
+// The result can be safely interface-upgraded to [hash.XOF].
 func NewXOF(size uint32, key []byte) (XOF, error) {
 	if len(key) > Size {
 		return nil, errKeySize
@@ -79,6 +83,10 @@ func (x *xof) Write(p []byte) (n int, err error) {
 func (x *xof) Clone() XOF {
 	clone := *x
 	return &clone
+}
+
+func (x *xof) BlockSize() int {
+	return x.d.BlockSize()
 }
 
 func (x *xof) Reset() {

--- a/blake2b/go125.go
+++ b/blake2b/go125.go
@@ -1,0 +1,11 @@
+// Copyright 2025 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.25
+
+package blake2b
+
+import "hash"
+
+var _ hash.XOF = (*xof)(nil)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a method to provide the block size for extended output functions.

* **Documentation**
  * Improved comments to recommend using the standard library’s hash interface and clarified compatibility with standard interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->